### PR TITLE
Configurable timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ $connection = (new SSHConnection())
             ->as('demo')
             ->withPassword('password')
          // ->withPrivateKey($privateKeyPath)
+         // ->timeout(0)
             ->connect();
 
 $command = $connection->run('echo "Hello world!"');

--- a/src/SSHConnection.php
+++ b/src/SSHConnection.php
@@ -18,6 +18,7 @@ class SSHConnection
     private $username;
     private $password;
     private $privateKeyPath;
+    private $timeout;
     private $connected = false;
     private $ssh;
 
@@ -48,6 +49,12 @@ class SSHConnection
     public function withPrivateKey(string $privateKeyPath): self
     {
         $this->privateKeyPath = $privateKeyPath;
+        return $this;
+    }
+
+    public function timeout(int $timeout): self
+    {
+        $this->timeout = $timeout;
         return $this;
     }
 
@@ -90,6 +97,10 @@ class SSHConnection
             if (!$authenticated) {
                 throw new RuntimeException('Error authenticating with password.');
             }
+        }
+
+        if ($this->timeout) {
+            $this->ssh->setTimeout($this->timeout);
         }
 
         $this->connected = true;


### PR DESCRIPTION
Long running commands (>10s) don't work reliable with this library. This allows to set a default timeout on a connection.